### PR TITLE
✨ feat: Add edit mode with deferred save and fix cross-lesson block DnD

### DIFF
--- a/src/app/(app)/mentor/courses/[id]/CourseBuilder.tsx
+++ b/src/app/(app)/mentor/courses/[id]/CourseBuilder.tsx
@@ -1,7 +1,7 @@
 // src/app/(app)/mentor/courses/[id]/CourseBuilder.tsx
 "use client";
 
-import { useState, useRef } from "react";
+import { useState, useRef, createContext, useContext } from "react";
 import { useRouter } from "next/navigation";
 import {
   GraduationCap, Plus, Trash2, ChevronDown, ChevronRight,
@@ -36,6 +36,12 @@ import { Card } from "@/modules/shared/components/Card";
 import { Modal } from "@/modules/shared/components/Modal";
 import { ContentBlockType } from "@prisma/client";
 import { formatDate } from "@/modules/shared/utils";
+
+// ─── Edit-mode context ────────────────────────────────────────────────────────
+// True while the user is in edit mode (changes are local; Save commits them).
+const EditModeContext = createContext(false);
+const useEditMode = () => useContext(EditModeContext);
+const makeTempId = () => `temp_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -120,15 +126,25 @@ function InlineEdit({
   onSave,
   className = "",
   placeholder = "Untitled",
+  readOnly = false,
 }: {
   value: string;
   onSave: (val: string) => Promise<void>;
   className?: string;
   placeholder?: string;
+  readOnly?: boolean;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
   const [saving, setSaving] = useState(false);
+
+  if (readOnly) {
+    return (
+      <span className={className}>
+        {value || <span className="text-surface-400 italic">{placeholder}</span>}
+      </span>
+    );
+  }
 
   async function save() {
     if (!draft.trim() || draft === value) { setEditing(false); setDraft(value); return; }
@@ -198,6 +214,8 @@ function AddBlockModal({
     return match ? match[1] : code.trim();
   }
 
+  const isEditing = useEditMode();
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
@@ -208,6 +226,20 @@ function AddBlockModal({
         : isIframe
         ? { src: extractSrc(embedCode) }
         : { url };
+
+      if (isEditing) {
+        // In edit mode: create a local temp block, skip the API
+        onAdded({
+          id: makeTempId(),
+          type,
+          title: blockTitle || null,
+          payload,
+          order: 0, // order is assigned by position in the array on save
+        });
+        onClose();
+        return;
+      }
+
       const requestBody = { type, title: blockTitle || undefined, payload };
       const res = await fetch(
         `/api/courses/${courseId}/modules/${moduleId}/lessons/${lessonId}/blocks`,
@@ -358,6 +390,7 @@ function EditBlockModal({
   const [embedSrc, setEmbedSrc] = useState(isIframe ? String(payload.src ?? "") : "");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const isEditing = useEditMode();
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -369,6 +402,14 @@ function EditBlockModal({
         : isIframe
         ? { src: embedSrc }
         : { url };
+
+      if (isEditing) {
+        // In edit mode: update block locally, skip the API
+        onSaved({ ...block, title: blockTitle || null, payload: newPayload });
+        onClose();
+        return;
+      }
+
       const res = await fetch(
         `/api/courses/${courseId}/modules/${moduleId}/lessons/${lessonId}/blocks/${block.id}`,
         {
@@ -643,6 +684,7 @@ function LessonRow({
   onDelete: (lessonId: string) => void;
   onBlocksChange: (blocks: Block[]) => void;
 }) {
+  const isEditing = useEditMode();
   const [expanded, setExpanded] = useState(false);
   const [addingBlock, setAddingBlock] = useState(false);
   const [editingBlock, setEditingBlock] = useState<Block | null>(null);
@@ -660,29 +702,33 @@ function LessonRow({
   };
 
   async function saveTitle(title: string) {
+    onUpdate({ ...lesson, title }); // always update local state
+    if (isEditing) return;
     await fetch(`/api/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title }),
     });
-    onUpdate({ ...lesson, title });
   }
 
   async function deleteLesson() {
     if (!confirm(`Delete lesson "${lesson.title}"? This cannot be undone.`)) return;
+    onDelete(lesson.id); // always update local state
+    if (isEditing) return;
     await fetch(`/api/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}`, {
       method: "DELETE",
     });
-    onDelete(lesson.id);
   }
 
   async function deleteBlock(blockId: string) {
     setDeletingBlock(blockId);
-    await fetch(
-      `/api/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}/blocks/${blockId}`,
-      { method: "DELETE" }
-    );
-    onBlocksChange(blocks.filter((b) => b.id !== blockId));
+    onBlocksChange(blocks.filter((b) => b.id !== blockId)); // always update local state
+    if (!isEditing) {
+      await fetch(
+        `/api/courses/${courseId}/modules/${moduleId}/lessons/${lesson.id}/blocks/${blockId}`,
+        { method: "DELETE" }
+      );
+    }
     setDeletingBlock(null);
   }
 
@@ -798,6 +844,7 @@ function ModuleSection({
   onUpdate: (updated: Module) => void;
   onDelete: (moduleId: string) => void;
 }) {
+  const isEditing = useEditMode();
   const [expanded, setExpanded] = useState(true);
   const [addingLesson, setAddingLesson] = useState(false);
   const [newLessonTitle, setNewLessonTitle] = useState("");
@@ -821,23 +868,40 @@ function ModuleSection({
   }
 
   async function saveModuleTitle(title: string) {
+    onUpdate({ ...mod, title }); // always update local state
+    if (isEditing) return;
     await fetch(`/api/courses/${courseId}/modules/${mod.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title }),
     });
-    onUpdate({ ...mod, title });
   }
 
   async function deleteModule() {
     if (!confirm(`Delete module "${mod.title}" and all its lessons? This cannot be undone.`)) return;
+    onDelete(mod.id); // always update local state
+    if (isEditing) return;
     await fetch(`/api/courses/${courseId}/modules/${mod.id}`, { method: "DELETE" });
-    onDelete(mod.id);
   }
 
   async function addLesson() {
     if (!newLessonTitle.trim()) return;
     setSaving(true);
+    if (isEditing) {
+      // In edit mode: create a temp lesson locally
+      const tempLesson: Lesson = {
+        id: makeTempId(),
+        title: newLessonTitle.trim(),
+        duration: null,
+        order: lessons.length + 1,
+        blocks: [],
+      };
+      setLessons((prev) => [...prev, tempLesson]);
+      setNewLessonTitle("");
+      setAddingLesson(false);
+      setSaving(false);
+      return;
+    }
     const res = await fetch(`/api/courses/${courseId}/modules/${mod.id}/lessons`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1069,6 +1133,73 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
   const [statusLoading, setStatusLoading] = useState(false);
   const [statusError, setStatusError] = useState<string | null>(null);
 
+  // ─── Edit mode ───────────────────────────────────────────────────────────
+  const [isEditing, setIsEditing] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const editSnapshot = useRef<{ course: Course; modules: Module[] } | null>(null);
+
+  function enterEdit() {
+    editSnapshot.current = {
+      course: JSON.parse(JSON.stringify(course)),
+      modules: JSON.parse(JSON.stringify(modules)),
+    };
+    setIsEditing(true);
+  }
+
+  function cancelEdit() {
+    if (editSnapshot.current) {
+      setCourse(editSnapshot.current.course);
+      setModules(editSnapshot.current.modules);
+    }
+    editSnapshot.current = null;
+    setIsEditing(false);
+    setSaveError(null);
+  }
+
+  async function saveEdit() {
+    setIsSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(`/api/courses/${course.id}/structure`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: course.title,
+          description: course.description,
+          modules: modules.map((m, mi) => ({
+            id: m.id,
+            title: m.title,
+            order: mi + 1,
+            lessons: m.lessons.map((l, li) => ({
+              id: l.id,
+              title: l.title,
+              order: li + 1,
+              blocks: l.blocks.map((b, bi) => ({
+                id: b.id,
+                type: b.type,
+                title: b.title,
+                payload: b.payload,
+                order: bi + 1,
+              })),
+            })),
+          })),
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error ?? "Failed to save");
+      // Replace state with server-confirmed structure (real IDs replace temp IDs)
+      if (data.modules) setModules(data.modules);
+      if (data.title) setCourse((prev) => ({ ...prev, title: data.title, description: data.description }));
+      editSnapshot.current = null;
+      setIsEditing(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
   // Active item being dragged (for DragOverlay)
   const [activeBlock, setActiveBlock] = useState<Block | null>(null);
   const [activeLesson, setActiveLesson] = useState<Lesson | null>(null);
@@ -1150,11 +1281,13 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
       const reordered = arrayMove(modules, oldIndex, newIndex).map((m, i) => ({ ...m, order: i + 1 }));
       setModules(reordered);
 
-      await fetch(`/api/courses/${course.id}/modules/reorder`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ order: reordered.map((m) => ({ id: m.id, order: m.order })) }),
-      });
+      if (!isEditing) {
+        await fetch(`/api/courses/${course.id}/modules/reorder`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ order: reordered.map((m) => ({ id: m.id, order: m.order })) }),
+        });
+      }
       return;
     }
 
@@ -1163,8 +1296,6 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
       const lessonId = activeId.replace("lesson-", "");
       const srcModuleId = src.moduleId;
 
-      // Determine target module from: sortable container "lessons-{moduleId}",
-      // droppable empty area "droppable-module-{moduleId}", or another lesson's module
       let targetModuleId: string;
       if (sortableContainerId?.startsWith("lessons-")) {
         targetModuleId = sortableContainerId.replace("lessons-", "");
@@ -1182,7 +1313,6 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
       if (!srcMod || !tgtMod) return;
 
       if (srcModuleId === targetModuleId) {
-        // Same module: reorder
         const oldIndex = srcMod.lessons.findIndex((l) => `lesson-${l.id}` === activeId);
         const newIndex = srcMod.lessons.findIndex((l) => `lesson-${l.id}` === overId);
         if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) return;
@@ -1190,17 +1320,18 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
         const reordered = arrayMove(srcMod.lessons, oldIndex, newIndex).map((l, i) => ({ ...l, order: i + 1 }));
         setModules((prev) => prev.map((m) => m.id === srcModuleId ? { ...m, lessons: reordered } : m));
 
-        await Promise.all(
-          reordered.map((l) =>
-            fetch(`/api/courses/${course.id}/modules/${srcModuleId}/lessons/${l.id}`, {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ order: l.order }),
-            })
-          )
-        );
+        if (!isEditing) {
+          await Promise.all(
+            reordered.map((l) =>
+              fetch(`/api/courses/${course.id}/modules/${srcModuleId}/lessons/${l.id}`, {
+                method: "PATCH",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ order: l.order }),
+              })
+            )
+          );
+        }
       } else {
-        // Cross-module move
         const lessonToMove = srcMod.lessons.find((l) => l.id === lessonId);
         if (!lessonToMove) return;
 
@@ -1224,36 +1355,33 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
           })
         );
 
-        // Move lesson to target module
-        await fetch(`/api/courses/${course.id}/modules/${srcModuleId}/lessons/${lessonId}`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ moduleId: targetModuleId, order: insertAt + 1 }),
-        });
-
-        // Fix source lesson orders
-        await Promise.all(
-          newSrcLessons.map((l) =>
-            fetch(`/api/courses/${course.id}/modules/${srcModuleId}/lessons/${l.id}`, {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ order: l.order }),
-            })
-          )
-        );
-
-        // Fix target lesson orders (excluding the moved one)
-        await Promise.all(
-          newTgtLessons
-            .filter((l) => l.id !== lessonId)
-            .map((l) =>
-              fetch(`/api/courses/${course.id}/modules/${targetModuleId}/lessons/${l.id}`, {
+        if (!isEditing) {
+          await fetch(`/api/courses/${course.id}/modules/${srcModuleId}/lessons/${lessonId}`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ moduleId: targetModuleId, order: insertAt + 1 }),
+          });
+          await Promise.all(
+            newSrcLessons.map((l) =>
+              fetch(`/api/courses/${course.id}/modules/${srcModuleId}/lessons/${l.id}`, {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({ order: l.order }),
               })
             )
-        );
+          );
+          await Promise.all(
+            newTgtLessons
+              .filter((l) => l.id !== lessonId)
+              .map((l) =>
+                fetch(`/api/courses/${course.id}/modules/${targetModuleId}/lessons/${l.id}`, {
+                  method: "PATCH",
+                  headers: { "Content-Type": "application/json" },
+                  body: JSON.stringify({ order: l.order }),
+                })
+              )
+          );
+        }
       }
       return;
     }
@@ -1262,18 +1390,38 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
     const srcLessonId = src.lessonId!;
     const srcModuleId = src.moduleId;
 
-    // Resolve target lesson:
-    // - over a sortable block: use its sortable containerId (= lesson.id set on SortableContext)
-    // - over a droppable empty area: id is `droppable-${lessonId}`
-    const droppableLesson = overId.startsWith("droppable-") && !overId.startsWith("droppable-module-")
-      ? overId.replace("droppable-", "")
+    // Resolve target lesson ID from drop position.
+    // Several possible cases:
+    //   1. Over a block in a lesson  → sortableContainerId = lesson.id, overBlockLessonId = lesson.id
+    //   2. Over a lesson's empty droppable area → overId = `droppable-${lessonId}`
+    //   3. Over a lesson row header  → overId = `lesson-${lessonId}`,
+    //                                  sortableContainerId = `lessons-${moduleId}` (NOT a lesson id)
+    // Case 3 used to fall through to `overId` which is an unrecognised key, causing silent failure.
+
+    // sortableContainerId is valid as a lesson ID only when it doesn't look like the
+    // lessons-level SortableContext ("lessons-…") or the module-level one ("module-…").
+    const containerIsLessonId =
+      sortableContainerId &&
+      !sortableContainerId.startsWith("lessons-") &&
+      !sortableContainerId.startsWith("module-");
+
+    const droppableLesson =
+      overId.startsWith("droppable-") && !overId.startsWith("droppable-module-")
+        ? overId.replace("droppable-", "")
+        : null;
+
+    // When over a lesson row header the id carries the "lesson-" prefix.
+    const overLessonHeader = overId.startsWith("lesson-")
+      ? overId.replace("lesson-", "")
       : null;
+
     const overBlockLessonId = over.data.current?.lessonId as string | undefined;
 
     const targetLessonId =
-      sortableContainerId ??
+      (containerIsLessonId ? sortableContainerId : undefined) ??
       overBlockLessonId ??
       droppableLesson ??
+      overLessonHeader ??   // drop onto a lesson header → block is appended to that lesson
       overId;
 
     if (!targetLessonId) return;
@@ -1296,19 +1444,19 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
       }));
       updateModuleBlocks(srcModuleId, srcLessonId, () => reordered);
 
-      // Persist new orders
-      await Promise.all(
-        reordered.map((b) =>
-          fetch(
-            `/api/courses/${course.id}/modules/${srcModuleId}/lessons/${srcLessonId}/blocks/${b.id}`,
-            {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ order: b.order }),
-            }
-          )
-        )
-      );
+      if (!isEditing) {
+        await fetch(`/api/courses/${course.id}/blocks/move`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            blockId: activeId,
+            sourceLessonId: srcLessonId,
+            targetLessonId: srcLessonId,
+            sourceBlocks: [],
+            targetBlocks: reordered.map((b) => ({ id: b.id, order: b.order })),
+          }),
+        });
+      }
     } else {
       // ── Cross-lesson move ──────────────────────────────────────────────
       const blockToMove = srcBlocks.find((b) => b.id === activeId);
@@ -1316,12 +1464,10 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
 
       const tgtBlocks = tgtLoc.lesson.blocks;
 
-      // Remove from source, renumber
       const newSrcBlocks = srcBlocks
         .filter((b) => b.id !== activeId)
         .map((b, i) => ({ ...b, order: i + 1 }));
 
-      // Insert into target: if dropped on a block, insert before it; else append
       const overIndex = tgtBlocks.findIndex((b) => b.id === overId);
       const insertAt = overIndex >= 0 ? overIndex : tgtBlocks.length;
       const newTgtBlocks = [
@@ -1330,7 +1476,6 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
         ...tgtBlocks.slice(insertAt),
       ].map((b, i) => ({ ...b, order: i + 1 }));
 
-      // Optimistic update
       setModules((prev) =>
         prev.map((m) => ({
           ...m,
@@ -1342,48 +1487,19 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
         }))
       );
 
-      // Move block to target lesson in DB (updates lessonId + order)
-      await fetch(
-        `/api/courses/${course.id}/modules/${srcModuleId}/lessons/${srcLessonId}/blocks/${activeId}`,
-        {
+      if (!isEditing) {
+        await fetch(`/api/courses/${course.id}/blocks/move`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ lessonId: targetLessonId, order: insertAt + 1 }),
-        }
-      );
-
-      // Fix remaining source block orders
-      if (newSrcBlocks.length > 0) {
-        await Promise.all(
-          newSrcBlocks.map((b) =>
-            fetch(
-              `/api/courses/${course.id}/modules/${srcModuleId}/lessons/${srcLessonId}/blocks/${b.id}`,
-              {
-                method: "PATCH",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ order: b.order }),
-              }
-            )
-          )
-        );
+          body: JSON.stringify({
+            blockId: activeId,
+            sourceLessonId: srcLessonId,
+            targetLessonId,
+            sourceBlocks: newSrcBlocks.map((b) => ({ id: b.id, order: b.order })),
+            targetBlocks: newTgtBlocks.map((b) => ({ id: b.id, order: b.order })),
+          }),
+        });
       }
-
-      // Fix target block orders (for blocks that shifted)
-      const tgtModuleId = tgtLoc.module.id;
-      await Promise.all(
-        newTgtBlocks
-          .filter((b) => b.id !== activeId)
-          .map((b) =>
-            fetch(
-              `/api/courses/${course.id}/modules/${tgtModuleId}/lessons/${targetLessonId}/blocks/${b.id}`,
-              {
-                method: "PATCH",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ order: b.order }),
-              }
-            )
-          )
-      );
     }
   }
 
@@ -1392,6 +1508,16 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
   async function addModule() {
     if (!newModuleTitle.trim()) return;
     setAddingModule2(true);
+    if (isEditing) {
+      setModules((prev) => [
+        ...prev,
+        { id: makeTempId(), title: newModuleTitle.trim(), order: prev.length + 1, lessons: [] },
+      ]);
+      setNewModuleTitle("");
+      setAddingModule(false);
+      setAddingModule2(false);
+      return;
+    }
     const res = await fetch(`/api/courses/${course.id}/modules`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -1425,27 +1551,30 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
   }
 
   async function saveCourseTitle(title: string) {
+    setCourse((prev) => ({ ...prev, title }));
+    if (isEditing) return;
     await fetch(`/api/courses/${course.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ title }),
     });
-    setCourse((prev) => ({ ...prev, title }));
   }
 
   async function saveCourseDescription(description: string) {
+    setCourse((prev) => ({ ...prev, description: description || null }));
+    if (isEditing) return;
     await fetch(`/api/courses/${course.id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ description: description || null }),
     });
-    setCourse((prev) => ({ ...prev, description: description || null }));
   }
 
   const isDraft = course.status === "DRAFT";
   const isPublished = course.status === "PUBLISHED";
 
   return (
+    <EditModeContext.Provider value={isEditing}>
     <DndContext
       sensors={sensors}
       collisionDetection={closestCenter}
@@ -1489,46 +1618,80 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
           </div>
 
           <div className="flex items-center gap-2 shrink-0">
-            {isDraft && (
-              <Button
-                size="sm"
-                leftIcon={<Eye className="w-4 h-4" />}
-                onClick={() => changeStatus("PUBLISHED")}
-                isLoading={statusLoading}
-              >
-                Publish
-              </Button>
-            )}
-            {isPublished && (
-              <Button
-                size="sm"
-                variant="outline"
-                leftIcon={<EyeOff className="w-4 h-4" />}
-                onClick={() => changeStatus("ARCHIVED")}
-                isLoading={statusLoading}
-              >
-                Archive
-              </Button>
-            )}
-            {course.status === "ARCHIVED" && (
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => changeStatus("PUBLISHED")}
-                isLoading={statusLoading}
-              >
-                Re-publish
-              </Button>
-            )}
-            {isDraft && (
-              <Button
-                size="sm"
-                variant="danger"
-                leftIcon={<Trash2 className="w-4 h-4" />}
-                onClick={deleteCourse}
-              >
-                Delete
-              </Button>
+            {isEditing ? (
+              <>
+                {saveError && (
+                  <span className="text-xs text-danger">{saveError}</span>
+                )}
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={cancelEdit}
+                  disabled={isSaving}
+                >
+                  Discard
+                </Button>
+                <Button
+                  size="sm"
+                  leftIcon={<Check className="w-4 h-4" />}
+                  onClick={saveEdit}
+                  isLoading={isSaving}
+                >
+                  Save
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  leftIcon={<Edit3 className="w-4 h-4" />}
+                  onClick={enterEdit}
+                >
+                  Edit Course
+                </Button>
+                {isDraft && (
+                  <Button
+                    size="sm"
+                    leftIcon={<Eye className="w-4 h-4" />}
+                    onClick={() => changeStatus("PUBLISHED")}
+                    isLoading={statusLoading}
+                  >
+                    Publish
+                  </Button>
+                )}
+                {isPublished && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    leftIcon={<EyeOff className="w-4 h-4" />}
+                    onClick={() => changeStatus("ARCHIVED")}
+                    isLoading={statusLoading}
+                  >
+                    Archive
+                  </Button>
+                )}
+                {course.status === "ARCHIVED" && (
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => changeStatus("PUBLISHED")}
+                    isLoading={statusLoading}
+                  >
+                    Re-publish
+                  </Button>
+                )}
+                {isDraft && (
+                  <Button
+                    size="sm"
+                    variant="danger"
+                    leftIcon={<Trash2 className="w-4 h-4" />}
+                    onClick={deleteCourse}
+                  >
+                    Delete
+                  </Button>
+                )}
+              </>
             )}
           </div>
         </div>
@@ -1622,5 +1785,6 @@ export function CourseBuilder({ course: initial }: { course: Course }) {
         {activeModule ? <ModuleDragOverlay mod={activeModule} /> : null}
       </DragOverlay>
     </DndContext>
+    </EditModeContext.Provider>
   );
 }

--- a/src/app/api/courses/[id]/blocks/move/route.ts
+++ b/src/app/api/courses/[id]/blocks/move/route.ts
@@ -1,0 +1,76 @@
+// src/app/api/courses/[id]/blocks/move/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth/auth-options";
+import { prisma } from "@/lib/db/prisma";
+import { z } from "zod";
+
+const orderItem = z.object({ id: z.string(), order: z.number().int().positive() });
+
+const schema = z.object({
+  blockId: z.string(),
+  sourceLessonId: z.string(),
+  targetLessonId: z.string(),
+  // Final order for all blocks remaining in the source lesson (empty if same-lesson move)
+  sourceBlocks: z.array(orderItem),
+  // Final order for all blocks in the target lesson, including the moved block
+  targetBlocks: z.array(orderItem),
+});
+
+// PATCH /api/courses/[id]/blocks/move
+// Atomically moves a block within or across lessons, reordering both lessons in one transaction.
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user.roles.includes("MENTOR")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: courseId } = await params;
+
+  const course = await prisma.course.findFirst({
+    where: { id: courseId, creatorId: session.user.id },
+    select: { id: true },
+  });
+  if (!course) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json();
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Validation failed", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { blockId, sourceLessonId, targetLessonId, sourceBlocks, targetBlocks } = parsed.data;
+  const crossLesson = sourceLessonId !== targetLessonId;
+  const offset = 10000;
+
+  // Collect all block ids involved so we can shift them to a safe range first,
+  // preventing transient (lessonId, order) unique constraint violations.
+  const allInvolved = [...targetBlocks, ...(crossLesson ? sourceBlocks : [])];
+
+  await prisma.$transaction([
+    // Step 1: shift all involved blocks to a safe temporary order range
+    ...allInvolved.map(({ id }) =>
+      prisma.contentBlock.update({
+        where: { id },
+        data: { order: offset + allInvolved.findIndex((b) => b.id === id) },
+      })
+    ),
+    // Step 2: move the block to the target lesson if cross-lesson
+    ...(crossLesson
+      ? [prisma.contentBlock.update({ where: { id: blockId }, data: { lessonId: targetLessonId } })]
+      : []),
+    // Step 3: apply final orders for target lesson blocks (includes moved block)
+    ...targetBlocks.map(({ id, order }) =>
+      prisma.contentBlock.update({ where: { id }, data: { order } })
+    ),
+    // Step 4: apply final orders for remaining source lesson blocks
+    ...sourceBlocks.map(({ id, order }) =>
+      prisma.contentBlock.update({ where: { id }, data: { order } })
+    ),
+  ]);
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/courses/[id]/structure/route.ts
+++ b/src/app/api/courses/[id]/structure/route.ts
@@ -1,0 +1,245 @@
+// src/app/api/courses/[id]/structure/route.ts
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth/auth-options";
+import { prisma } from "@/lib/db/prisma";
+import { z } from "zod";
+import { ContentBlockType } from "@prisma/client";
+import { InputJsonValue } from "@prisma/client/runtime/library";
+
+const blockSchema = z.object({
+  id: z.string(),
+  type: z.nativeEnum(ContentBlockType),
+  title: z.string().max(200).nullable(),
+  payload: z.record(z.unknown()),
+  order: z.number().int().positive(),
+});
+
+const lessonSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1).max(200),
+  order: z.number().int().positive(),
+  blocks: z.array(blockSchema),
+});
+
+const moduleSchema = z.object({
+  id: z.string(),
+  title: z.string().min(1).max(200),
+  order: z.number().int().positive(),
+  lessons: z.array(lessonSchema),
+});
+
+const structureSchema = z.object({
+  title: z.string().min(1).max(200).optional(),
+  description: z.string().max(2000).nullable().optional(),
+  modules: z.array(moduleSchema),
+});
+
+const isTemp = (id: string) => id.startsWith("temp_");
+
+// PUT /api/courses/[id]/structure
+// Reconciles the full course structure in one interactive transaction.
+// New items have IDs prefixed with "temp_"; existing items have real DB IDs.
+// Returns the saved structure with all real IDs so the client can update its state.
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user.roles.includes("MENTOR")) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: courseId } = await params;
+
+  const existing = await prisma.course.findFirst({
+    where: { id: courseId, creatorId: session.user.id },
+    include: {
+      modules: {
+        include: { lessons: { include: { blocks: true } } },
+      },
+    },
+  });
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const body = await req.json();
+  const parsed = structureSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Validation failed", details: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
+  const payload = parsed.data;
+
+  // ── Collect existing IDs ────────────────────────────────────────────────────
+  const existingModuleIds = new Set(existing.modules.map((m) => m.id));
+  const existingLessonIds = new Set(
+    existing.modules.flatMap((m) => m.lessons.map((l) => l.id))
+  );
+  const existingBlockIds = new Set(
+    existing.modules.flatMap((m) => m.lessons.flatMap((l) => l.blocks.map((b) => b.id)))
+  );
+
+  // IDs present in payload (real only — temp IDs are new)
+  const payloadModuleIds = new Set(
+    payload.modules.filter((m) => !isTemp(m.id)).map((m) => m.id)
+  );
+  const payloadLessonIds = new Set(
+    payload.modules.flatMap((m) => m.lessons.filter((l) => !isTemp(l.id)).map((l) => l.id))
+  );
+  const payloadBlockIds = new Set(
+    payload.modules.flatMap((m) =>
+      m.lessons.flatMap((l) => l.blocks.filter((b) => !isTemp(b.id)).map((b) => b.id))
+    )
+  );
+
+  // IDs to delete (in DB but absent from payload)
+  const moduleIdsToDelete = [...existingModuleIds].filter((id) => !payloadModuleIds.has(id));
+  const lessonIdsToDelete = [...existingLessonIds].filter((id) => !payloadLessonIds.has(id));
+  const blockIdsToDelete = [...existingBlockIds].filter((id) => !payloadBlockIds.has(id));
+
+  // ── temp ID → real ID maps (filled during transaction) ─────────────────────
+  const moduleIdMap: Record<string, string> = {};
+  const lessonIdMap: Record<string, string> = {};
+
+  // ── Run interactive transaction ─────────────────────────────────────────────
+  const OFFSET = 100_000; // safe range above any real order value
+
+  await prisma.$transaction(
+    async (tx) => {
+      // 1. Update course-level fields
+      if (payload.title !== undefined || payload.description !== undefined) {
+        await tx.course.update({
+          where: { id: courseId },
+          data: {
+            ...(payload.title !== undefined ? { title: payload.title } : {}),
+            ...(payload.description !== undefined
+              ? { description: payload.description }
+              : {}),
+          },
+        });
+      }
+
+      // 2. Delete removed items (module cascade handles nested lessons + blocks)
+      if (moduleIdsToDelete.length > 0) {
+        await tx.courseModule.deleteMany({ where: { id: { in: moduleIdsToDelete } } });
+      }
+      if (lessonIdsToDelete.length > 0) {
+        await tx.lesson.deleteMany({ where: { id: { in: lessonIdsToDelete } } });
+      }
+      if (blockIdsToDelete.length > 0) {
+        await tx.contentBlock.deleteMany({ where: { id: { in: blockIdsToDelete } } });
+      }
+
+      // 3. Shift all surviving existing items to offset range to avoid unique
+      //    constraint collisions while we reorder them.
+      if (existingModuleIds.size > 0) {
+        await tx.courseModule.updateMany({
+          where: { courseId, id: { in: [...existingModuleIds] } },
+          data: { order: { increment: OFFSET } },
+        });
+      }
+      if (existingLessonIds.size > 0) {
+        await tx.lesson.updateMany({
+          where: { id: { in: [...existingLessonIds] } },
+          data: { order: { increment: OFFSET } },
+        });
+      }
+      if (existingBlockIds.size > 0) {
+        await tx.contentBlock.updateMany({
+          where: { id: { in: [...existingBlockIds] } },
+          data: { order: { increment: OFFSET } },
+        });
+      }
+
+      // 4. Create / update modules
+      for (const mod of payload.modules) {
+        if (isTemp(mod.id)) {
+          const created = await tx.courseModule.create({
+            data: { title: mod.title, order: mod.order, courseId },
+          });
+          moduleIdMap[mod.id] = created.id;
+        } else {
+          await tx.courseModule.update({
+            where: { id: mod.id },
+            data: { title: mod.title, order: mod.order },
+          });
+          moduleIdMap[mod.id] = mod.id;
+        }
+      }
+
+      // 5. Create / update lessons
+      for (const mod of payload.modules) {
+        const realModuleId = moduleIdMap[mod.id];
+        for (const lesson of mod.lessons) {
+          if (isTemp(lesson.id)) {
+            const created = await tx.lesson.create({
+              data: { title: lesson.title, order: lesson.order, moduleId: realModuleId },
+            });
+            lessonIdMap[lesson.id] = created.id;
+          } else {
+            await tx.lesson.update({
+              where: { id: lesson.id },
+              data: { title: lesson.title, order: lesson.order, moduleId: realModuleId },
+            });
+            lessonIdMap[lesson.id] = lesson.id;
+          }
+        }
+      }
+
+      // 6. Create / update blocks
+      for (const mod of payload.modules) {
+        for (const lesson of mod.lessons) {
+          const realLessonId = lessonIdMap[lesson.id];
+          for (const block of lesson.blocks) {
+            if (isTemp(block.id)) {
+              await tx.contentBlock.create({
+                data: {
+                  type: block.type,
+                  title: block.title,
+                  payload: block.payload as InputJsonValue,
+                  order: block.order,
+                  lessonId: realLessonId,
+                },
+              });
+            } else {
+              await tx.contentBlock.update({
+                where: { id: block.id },
+                data: {
+                  title: block.title,
+                  payload: block.payload as InputJsonValue,
+                  order: block.order,
+                  lessonId: realLessonId,
+                },
+              });
+            }
+          }
+        }
+      }
+    },
+    { timeout: 15000 }
+  );
+
+  // ── Return the saved structure with real IDs ─────────────────────────────────
+  const saved = await prisma.course.findUnique({
+    where: { id: courseId },
+    select: {
+      id: true,
+      title: true,
+      description: true,
+      modules: {
+        orderBy: { order: "asc" },
+        include: {
+          lessons: {
+            orderBy: { order: "asc" },
+            include: { blocks: { orderBy: { order: "asc" } } },
+          },
+        },
+      },
+    },
+  });
+
+  return NextResponse.json(saved);
+}


### PR DESCRIPTION
- Add Edit/Save/Discard workflow — all changes (drag-drop, rename, add, delete) are local until "Save" commits them in one atomic transaction
- Add PUT /api/courses/[id]/structure to reconcile full course structure; temp IDs (temp_*) are created in DB and replaced with real IDs on save
- Add PATCH /api/courses/[id]/blocks/move to atomically move/reorder blocks across lessons without hitting (lessonId, order) constraint
- Fix cross-lesson block drag: correctly resolve target lesson when dropping on a lesson header or collapsed lesson row; filter out lessons-level SortableContext IDs that were causing silent failures
- Use EditModeContext to skip API calls in all mutation paths during edit